### PR TITLE
Fix rendering issue for non-zero start dots

### DIFF
--- a/src/Dots.js
+++ b/src/Dots.js
@@ -27,7 +27,7 @@ export default class Dots extends Component {
   constructor (props) {
     super(props)
     this.state = {
-      previousIndex: null
+      previousIndex: props.index || 0
     }
   }
 

--- a/src/Dots.js
+++ b/src/Dots.js
@@ -54,7 +54,7 @@ export default class Dots extends Component {
   }
 
   render () {
-    const {count, index, style = {}, ...other} = this.props
+    const {count, index, style = {}, onDotClick, ...other} = this.props
     const {previousIndex} = this.state
 
     return (
@@ -66,7 +66,7 @@ export default class Dots extends Component {
               style={{
                 ...styles.dotOuter,
                 left: i * 16,
-                cursor: this.props.onDotClick != null ? 'pointer' : 'inherit'
+                cursor: onDotClick != null ? 'pointer' : 'inherit'
               }}
               onTouchTap={(event) => this.handleDotClick(i, event)}
             >

--- a/src/Dots.js
+++ b/src/Dots.js
@@ -54,11 +54,11 @@ export default class Dots extends Component {
   }
 
   render () {
-    const {count, index, style = {}} = this.props
+    const {count, index, style = {}, ...other} = this.props
     const {previousIndex} = this.state
 
     return (
-      <div style={{...style, width: count * 16}}>
+      <div style={{...style, width: count * 16}} {...other}>
         <div style={styles.dots}>
           {[...Array(count).keys()].map((i) => (
             <div

--- a/src/Dots.js
+++ b/src/Dots.js
@@ -47,9 +47,9 @@ export default class Dots extends Component {
     }
   }
 
-  handleDotClick = (index) => {
+  handleDotClick = (index, event) => {
     if (this.props.onDotClick != null) {
-      this.props.onDotClick(index)
+      this.props.onDotClick(index, event)
     }
   }
 
@@ -68,7 +68,7 @@ export default class Dots extends Component {
                 left: i * 16,
                 cursor: this.props.onDotClick != null ? 'pointer' : 'inherit'
               }}
-              onTouchTap={() => this.handleDotClick(i)}
+              onTouchTap={(event) => this.handleDotClick(i, event)}
             >
               <Paper
                 circle


### PR DESCRIPTION
Noticed a rendering error that occurred when you rendered a Dots component with the initial index not set to 0, so I fixed that.

I also exposed the event for `onDotClick` so you can use that if necessary. It's not a particularly great syntax here, realistically the event would be first, but it's at least backwards compatible :)