### PR TITLE
Add a dotColor property

### DIFF
--- a/src/Dots.js
+++ b/src/Dots.js
@@ -22,17 +22,11 @@ const styles = {
   }
 }
 
-const prepareDotStyle = dotColor => ({
-  ...styles.dot,
-  backgroundColor: dotColor
-})
-
 export default class Dots extends Component {
   constructor (props) {
     super(props)
     this.state = {
-      previousIndex: props.index || 0,
-      dotStyle: prepareDotStyle(props.dotColor)
+      previousIndex: props.index || 0
     }
   }
 
@@ -43,10 +37,6 @@ export default class Dots extends Component {
         this.timeout = null
         this.setState({previousIndex: index})
       }, 450)
-    }
-
-    if (dotColor !== this.props.dotColor) {
-      this.setState({dotStyle: prepareDotStyle(dotColor)})
     }
   }
 
@@ -64,7 +54,7 @@ export default class Dots extends Component {
 
   render () {
     const {count, index, style = {}, onDotClick, dotColor, ...other} = this.props
-    const {previousIndex, dotStyle} = this.state
+    const {previousIndex} = this.state
 
     return (
       <div style={{...style, width: count * 16}} {...other}>
@@ -83,7 +73,7 @@ export default class Dots extends Component {
                 circle
                 zDepth={0}
                 style={{
-                  ...dotStyle,
+                  backgroundColor: dotColor,
                   opacity: i >= Math.min(previousIndex, index) && i <= Math.max(previousIndex, index) ? 0 : 0.5
                 }}
               />
@@ -92,7 +82,7 @@ export default class Dots extends Component {
           <Paper
             zDepth={0}
             style={{
-              ...dotStyle,
+              backgroundColor: dotColor,
               position: 'absolute',
               marginTop: 4,
               left: Math.min(previousIndex, index) * 16 + 4,

--- a/src/Dots.js
+++ b/src/Dots.js
@@ -24,8 +24,8 @@ const styles = {
 
 const prepareDotStyle = dotColor => ({
   ...styles.dot,
-  background: dotColor
-});
+  backgroundColor: dotColor
+})
 
 export default class Dots extends Component {
   constructor (props) {
@@ -44,7 +44,7 @@ export default class Dots extends Component {
         this.setState({previousIndex: index})
       }, 450)
     }
-    
+
     if (dotColor !== this.props.dotColor) {
       this.setState({dotStyle: prepareDotStyle(dotColor)})
     }

--- a/src/Dots.js
+++ b/src/Dots.js
@@ -73,6 +73,7 @@ export default class Dots extends Component {
                 circle
                 zDepth={0}
                 style={{
+                  ...styles.dot,
                   backgroundColor: dotColor,
                   opacity: i >= Math.min(previousIndex, index) && i <= Math.max(previousIndex, index) ? 0 : 0.5
                 }}
@@ -82,6 +83,7 @@ export default class Dots extends Component {
           <Paper
             zDepth={0}
             style={{
+              ...styles.dot,
               backgroundColor: dotColor,
               position: 'absolute',
               marginTop: 4,

--- a/src/Dots.js
+++ b/src/Dots.js
@@ -17,27 +17,36 @@ const styles = {
   dot: {
     width: 8,
     height: 8,
-    background: '#fff',
     transition: 'all 400ms cubic-bezier(0.4, 0.0, 0.2, 1)',
     borderRadius: 4
   }
 }
 
+const prepareDotStyle = dotColor => ({
+  ...styles.dot,
+  background: dotColor
+});
+
 export default class Dots extends Component {
   constructor (props) {
     super(props)
     this.state = {
-      previousIndex: props.index || 0
+      previousIndex: props.index || 0,
+      dotStyle: prepareDotStyle(props.dotColor)
     }
   }
 
-  componentWillReceiveProps ({index}) {
+  componentWillReceiveProps ({index, dotColor}) {
     if (index !== this.props.index) {
       this.setState({previousIndex: this.props.index})
       this.timeout = setTimeout(() => {
         this.timeout = null
         this.setState({previousIndex: index})
       }, 450)
+    }
+    
+    if (dotColor !== this.props.dotColor) {
+      this.setState({dotStyle: prepareDotStyle(dotColor)})
     }
   }
 
@@ -54,8 +63,8 @@ export default class Dots extends Component {
   }
 
   render () {
-    const {count, index, style = {}, onDotClick, ...other} = this.props
-    const {previousIndex} = this.state
+    const {count, index, style = {}, onDotClick, dotColor, ...other} = this.props
+    const {previousIndex, dotStyle} = this.state
 
     return (
       <div style={{...style, width: count * 16}} {...other}>
@@ -74,7 +83,7 @@ export default class Dots extends Component {
                 circle
                 zDepth={0}
                 style={{
-                  ...styles.dot,
+                  ...dotStyle,
                   opacity: i >= Math.min(previousIndex, index) && i <= Math.max(previousIndex, index) ? 0 : 0.5
                 }}
               />
@@ -83,7 +92,7 @@ export default class Dots extends Component {
           <Paper
             zDepth={0}
             style={{
-              ...styles.dot,
+              ...dotStyle,
               position: 'absolute',
               marginTop: 4,
               left: Math.min(previousIndex, index) * 16 + 4,
@@ -100,5 +109,10 @@ Dots.propTypes = {
   count: PropTypes.number.isRequired,
   index: PropTypes.number.isRequired,
   style: PropTypes.object,
+  dotColor: PropTypes.string,
   onDotClick: PropTypes.func
+}
+
+Dots.defaultProps = {
+  dotColor: '#fff'
 }

--- a/src/Dots.spec.js
+++ b/src/Dots.spec.js
@@ -48,3 +48,14 @@ test('onDotClick handler', () => {
   )
   expect(tree).toMatchSnapshot()
 })
+
+test('custom dot color', () => {
+  const tree = renderer.create(
+    <ThemedDots
+      count={4}
+      index={0}
+      dotColor='red'
+    />
+  )
+  expect(tree).toMatchSnapshot()
+})

--- a/src/__snapshots__/Dots.spec.js.snap
+++ b/src/__snapshots__/Dots.spec.js.snap
@@ -1,5 +1,177 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`custom dot color 1`] = `
+<div
+  style={
+    Object {
+      "width": 64,
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "padding": "20px 0 28px",
+        "position": "relative",
+      }
+    }
+  >
+    <div
+      onClick={[Function]}
+      style={
+        Object {
+          "cursor": "inherit",
+          "float": "left",
+          "height": 8,
+          "left": 0,
+          "padding": 4,
+          "position": "absolute",
+          "width": 8,
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+            "backgroundColor": "red",
+            "borderRadius": 4,
+            "boxShadow": undefined,
+            "boxSizing": "border-box",
+            "color": "rgba(0, 0, 0, 0.87)",
+            "fontFamily": "Roboto, sans-serif",
+            "height": 8,
+            "muiPrepared": true,
+            "opacity": 0,
+            "transition": "all 400ms cubic-bezier(0.4, 0.0, 0.2, 1)",
+            "width": 8,
+          }
+        }
+      />
+    </div>
+    <div
+      onClick={[Function]}
+      style={
+        Object {
+          "cursor": "inherit",
+          "float": "left",
+          "height": 8,
+          "left": 16,
+          "padding": 4,
+          "position": "absolute",
+          "width": 8,
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+            "backgroundColor": "red",
+            "borderRadius": 4,
+            "boxShadow": undefined,
+            "boxSizing": "border-box",
+            "color": "rgba(0, 0, 0, 0.87)",
+            "fontFamily": "Roboto, sans-serif",
+            "height": 8,
+            "muiPrepared": true,
+            "opacity": 0.5,
+            "transition": "all 400ms cubic-bezier(0.4, 0.0, 0.2, 1)",
+            "width": 8,
+          }
+        }
+      />
+    </div>
+    <div
+      onClick={[Function]}
+      style={
+        Object {
+          "cursor": "inherit",
+          "float": "left",
+          "height": 8,
+          "left": 32,
+          "padding": 4,
+          "position": "absolute",
+          "width": 8,
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+            "backgroundColor": "red",
+            "borderRadius": 4,
+            "boxShadow": undefined,
+            "boxSizing": "border-box",
+            "color": "rgba(0, 0, 0, 0.87)",
+            "fontFamily": "Roboto, sans-serif",
+            "height": 8,
+            "muiPrepared": true,
+            "opacity": 0.5,
+            "transition": "all 400ms cubic-bezier(0.4, 0.0, 0.2, 1)",
+            "width": 8,
+          }
+        }
+      />
+    </div>
+    <div
+      onClick={[Function]}
+      style={
+        Object {
+          "cursor": "inherit",
+          "float": "left",
+          "height": 8,
+          "left": 48,
+          "padding": 4,
+          "position": "absolute",
+          "width": 8,
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+            "backgroundColor": "red",
+            "borderRadius": 4,
+            "boxShadow": undefined,
+            "boxSizing": "border-box",
+            "color": "rgba(0, 0, 0, 0.87)",
+            "fontFamily": "Roboto, sans-serif",
+            "height": 8,
+            "muiPrepared": true,
+            "opacity": 0.5,
+            "transition": "all 400ms cubic-bezier(0.4, 0.0, 0.2, 1)",
+            "width": 8,
+          }
+        }
+      />
+    </div>
+    <div
+      style={
+        Object {
+          "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+          "backgroundColor": "red",
+          "borderRadius": 4,
+          "boxShadow": undefined,
+          "boxSizing": "border-box",
+          "color": "rgba(0, 0, 0, 0.87)",
+          "fontFamily": "Roboto, sans-serif",
+          "height": 8,
+          "left": 4,
+          "marginTop": 4,
+          "muiPrepared": true,
+          "position": "absolute",
+          "transition": "all 400ms cubic-bezier(0.4, 0.0, 0.2, 1)",
+          "width": 8,
+        }
+      }
+    />
+  </div>
+</div>
+`;
+
 exports[`custom style 1`] = `
 <div
   style={
@@ -35,8 +207,7 @@ exports[`custom style 1`] = `
         style={
           Object {
             "WebkitTapHighlightColor": "rgba(0,0,0,0)",
-            "background": "#fff",
-            "backgroundColor": "#ffffff",
+            "backgroundColor": "#fff",
             "borderRadius": 4,
             "boxShadow": undefined,
             "boxSizing": "border-box",
@@ -69,8 +240,7 @@ exports[`custom style 1`] = `
         style={
           Object {
             "WebkitTapHighlightColor": "rgba(0,0,0,0)",
-            "background": "#fff",
-            "backgroundColor": "#ffffff",
+            "backgroundColor": "#fff",
             "borderRadius": 4,
             "boxShadow": undefined,
             "boxSizing": "border-box",
@@ -103,8 +273,7 @@ exports[`custom style 1`] = `
         style={
           Object {
             "WebkitTapHighlightColor": "rgba(0,0,0,0)",
-            "background": "#fff",
-            "backgroundColor": "#ffffff",
+            "backgroundColor": "#fff",
             "borderRadius": 4,
             "boxShadow": undefined,
             "boxSizing": "border-box",
@@ -137,8 +306,7 @@ exports[`custom style 1`] = `
         style={
           Object {
             "WebkitTapHighlightColor": "rgba(0,0,0,0)",
-            "background": "#fff",
-            "backgroundColor": "#ffffff",
+            "backgroundColor": "#fff",
             "borderRadius": 4,
             "boxShadow": undefined,
             "boxSizing": "border-box",
@@ -171,8 +339,7 @@ exports[`custom style 1`] = `
         style={
           Object {
             "WebkitTapHighlightColor": "rgba(0,0,0,0)",
-            "background": "#fff",
-            "backgroundColor": "#ffffff",
+            "backgroundColor": "#fff",
             "borderRadius": 4,
             "boxShadow": undefined,
             "boxSizing": "border-box",
@@ -191,8 +358,7 @@ exports[`custom style 1`] = `
       style={
         Object {
           "WebkitTapHighlightColor": "rgba(0,0,0,0)",
-          "background": "#fff",
-          "backgroundColor": "#ffffff",
+          "backgroundColor": "#fff",
           "borderRadius": 4,
           "boxShadow": undefined,
           "boxSizing": "border-box",
@@ -246,8 +412,7 @@ exports[`onDotClick handler 1`] = `
         style={
           Object {
             "WebkitTapHighlightColor": "rgba(0,0,0,0)",
-            "background": "#fff",
-            "backgroundColor": "#ffffff",
+            "backgroundColor": "#fff",
             "borderRadius": 4,
             "boxShadow": undefined,
             "boxSizing": "border-box",
@@ -280,8 +445,7 @@ exports[`onDotClick handler 1`] = `
         style={
           Object {
             "WebkitTapHighlightColor": "rgba(0,0,0,0)",
-            "background": "#fff",
-            "backgroundColor": "#ffffff",
+            "backgroundColor": "#fff",
             "borderRadius": 4,
             "boxShadow": undefined,
             "boxSizing": "border-box",
@@ -314,8 +478,7 @@ exports[`onDotClick handler 1`] = `
         style={
           Object {
             "WebkitTapHighlightColor": "rgba(0,0,0,0)",
-            "background": "#fff",
-            "backgroundColor": "#ffffff",
+            "backgroundColor": "#fff",
             "borderRadius": 4,
             "boxShadow": undefined,
             "boxSizing": "border-box",
@@ -334,8 +497,7 @@ exports[`onDotClick handler 1`] = `
       style={
         Object {
           "WebkitTapHighlightColor": "rgba(0,0,0,0)",
-          "background": "#fff",
-          "backgroundColor": "#ffffff",
+          "backgroundColor": "#fff",
           "borderRadius": 4,
           "boxShadow": undefined,
           "boxSizing": "border-box",
@@ -389,8 +551,7 @@ exports[`three dots, first is selected 1`] = `
         style={
           Object {
             "WebkitTapHighlightColor": "rgba(0,0,0,0)",
-            "background": "#fff",
-            "backgroundColor": "#ffffff",
+            "backgroundColor": "#fff",
             "borderRadius": 4,
             "boxShadow": undefined,
             "boxSizing": "border-box",
@@ -423,8 +584,7 @@ exports[`three dots, first is selected 1`] = `
         style={
           Object {
             "WebkitTapHighlightColor": "rgba(0,0,0,0)",
-            "background": "#fff",
-            "backgroundColor": "#ffffff",
+            "backgroundColor": "#fff",
             "borderRadius": 4,
             "boxShadow": undefined,
             "boxSizing": "border-box",
@@ -457,8 +617,7 @@ exports[`three dots, first is selected 1`] = `
         style={
           Object {
             "WebkitTapHighlightColor": "rgba(0,0,0,0)",
-            "background": "#fff",
-            "backgroundColor": "#ffffff",
+            "backgroundColor": "#fff",
             "borderRadius": 4,
             "boxShadow": undefined,
             "boxSizing": "border-box",
@@ -477,8 +636,7 @@ exports[`three dots, first is selected 1`] = `
       style={
         Object {
           "WebkitTapHighlightColor": "rgba(0,0,0,0)",
-          "background": "#fff",
-          "backgroundColor": "#ffffff",
+          "backgroundColor": "#fff",
           "borderRadius": 4,
           "boxShadow": undefined,
           "boxSizing": "border-box",

--- a/src/__snapshots__/Dots.spec.js.snap
+++ b/src/__snapshots__/Dots.spec.js.snap
@@ -35,14 +35,16 @@ exports[`custom dot color 1`] = `
           Object {
             "WebkitTapHighlightColor": "rgba(0,0,0,0)",
             "backgroundColor": "red",
-            "borderRadius": "50%",
+            "borderRadius": 4,
             "boxShadow": undefined,
             "boxSizing": "border-box",
             "color": "rgba(0, 0, 0, 0.87)",
             "fontFamily": "Roboto, sans-serif",
+            "height": 8,
             "muiPrepared": true,
             "opacity": 0,
-            "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+            "transition": "all 400ms cubic-bezier(0.4, 0.0, 0.2, 1)",
+            "width": 8,
           }
         }
       />
@@ -66,14 +68,16 @@ exports[`custom dot color 1`] = `
           Object {
             "WebkitTapHighlightColor": "rgba(0,0,0,0)",
             "backgroundColor": "red",
-            "borderRadius": "50%",
+            "borderRadius": 4,
             "boxShadow": undefined,
             "boxSizing": "border-box",
             "color": "rgba(0, 0, 0, 0.87)",
             "fontFamily": "Roboto, sans-serif",
+            "height": 8,
             "muiPrepared": true,
             "opacity": 0.5,
-            "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+            "transition": "all 400ms cubic-bezier(0.4, 0.0, 0.2, 1)",
+            "width": 8,
           }
         }
       />
@@ -97,14 +101,16 @@ exports[`custom dot color 1`] = `
           Object {
             "WebkitTapHighlightColor": "rgba(0,0,0,0)",
             "backgroundColor": "red",
-            "borderRadius": "50%",
+            "borderRadius": 4,
             "boxShadow": undefined,
             "boxSizing": "border-box",
             "color": "rgba(0, 0, 0, 0.87)",
             "fontFamily": "Roboto, sans-serif",
+            "height": 8,
             "muiPrepared": true,
             "opacity": 0.5,
-            "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+            "transition": "all 400ms cubic-bezier(0.4, 0.0, 0.2, 1)",
+            "width": 8,
           }
         }
       />
@@ -128,14 +134,16 @@ exports[`custom dot color 1`] = `
           Object {
             "WebkitTapHighlightColor": "rgba(0,0,0,0)",
             "backgroundColor": "red",
-            "borderRadius": "50%",
+            "borderRadius": 4,
             "boxShadow": undefined,
             "boxSizing": "border-box",
             "color": "rgba(0, 0, 0, 0.87)",
             "fontFamily": "Roboto, sans-serif",
+            "height": 8,
             "muiPrepared": true,
             "opacity": 0.5,
-            "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+            "transition": "all 400ms cubic-bezier(0.4, 0.0, 0.2, 1)",
+            "width": 8,
           }
         }
       />
@@ -145,16 +153,17 @@ exports[`custom dot color 1`] = `
         Object {
           "WebkitTapHighlightColor": "rgba(0,0,0,0)",
           "backgroundColor": "red",
-          "borderRadius": 2,
+          "borderRadius": 4,
           "boxShadow": undefined,
           "boxSizing": "border-box",
           "color": "rgba(0, 0, 0, 0.87)",
           "fontFamily": "Roboto, sans-serif",
+          "height": 8,
           "left": 4,
           "marginTop": 4,
           "muiPrepared": true,
           "position": "absolute",
-          "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+          "transition": "all 400ms cubic-bezier(0.4, 0.0, 0.2, 1)",
           "width": 8,
         }
       }
@@ -199,14 +208,16 @@ exports[`custom style 1`] = `
           Object {
             "WebkitTapHighlightColor": "rgba(0,0,0,0)",
             "backgroundColor": "#fff",
-            "borderRadius": "50%",
+            "borderRadius": 4,
             "boxShadow": undefined,
             "boxSizing": "border-box",
             "color": "rgba(0, 0, 0, 0.87)",
             "fontFamily": "Roboto, sans-serif",
+            "height": 8,
             "muiPrepared": true,
             "opacity": 0,
-            "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+            "transition": "all 400ms cubic-bezier(0.4, 0.0, 0.2, 1)",
+            "width": 8,
           }
         }
       />
@@ -230,14 +241,16 @@ exports[`custom style 1`] = `
           Object {
             "WebkitTapHighlightColor": "rgba(0,0,0,0)",
             "backgroundColor": "#fff",
-            "borderRadius": "50%",
+            "borderRadius": 4,
             "boxShadow": undefined,
             "boxSizing": "border-box",
             "color": "rgba(0, 0, 0, 0.87)",
             "fontFamily": "Roboto, sans-serif",
+            "height": 8,
             "muiPrepared": true,
             "opacity": 0.5,
-            "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+            "transition": "all 400ms cubic-bezier(0.4, 0.0, 0.2, 1)",
+            "width": 8,
           }
         }
       />
@@ -261,14 +274,16 @@ exports[`custom style 1`] = `
           Object {
             "WebkitTapHighlightColor": "rgba(0,0,0,0)",
             "backgroundColor": "#fff",
-            "borderRadius": "50%",
+            "borderRadius": 4,
             "boxShadow": undefined,
             "boxSizing": "border-box",
             "color": "rgba(0, 0, 0, 0.87)",
             "fontFamily": "Roboto, sans-serif",
+            "height": 8,
             "muiPrepared": true,
             "opacity": 0.5,
-            "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+            "transition": "all 400ms cubic-bezier(0.4, 0.0, 0.2, 1)",
+            "width": 8,
           }
         }
       />
@@ -292,14 +307,16 @@ exports[`custom style 1`] = `
           Object {
             "WebkitTapHighlightColor": "rgba(0,0,0,0)",
             "backgroundColor": "#fff",
-            "borderRadius": "50%",
+            "borderRadius": 4,
             "boxShadow": undefined,
             "boxSizing": "border-box",
             "color": "rgba(0, 0, 0, 0.87)",
             "fontFamily": "Roboto, sans-serif",
+            "height": 8,
             "muiPrepared": true,
             "opacity": 0.5,
-            "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+            "transition": "all 400ms cubic-bezier(0.4, 0.0, 0.2, 1)",
+            "width": 8,
           }
         }
       />
@@ -323,14 +340,16 @@ exports[`custom style 1`] = `
           Object {
             "WebkitTapHighlightColor": "rgba(0,0,0,0)",
             "backgroundColor": "#fff",
-            "borderRadius": "50%",
+            "borderRadius": 4,
             "boxShadow": undefined,
             "boxSizing": "border-box",
             "color": "rgba(0, 0, 0, 0.87)",
             "fontFamily": "Roboto, sans-serif",
+            "height": 8,
             "muiPrepared": true,
             "opacity": 0.5,
-            "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+            "transition": "all 400ms cubic-bezier(0.4, 0.0, 0.2, 1)",
+            "width": 8,
           }
         }
       />
@@ -340,16 +359,17 @@ exports[`custom style 1`] = `
         Object {
           "WebkitTapHighlightColor": "rgba(0,0,0,0)",
           "backgroundColor": "#fff",
-          "borderRadius": 2,
+          "borderRadius": 4,
           "boxShadow": undefined,
           "boxSizing": "border-box",
           "color": "rgba(0, 0, 0, 0.87)",
           "fontFamily": "Roboto, sans-serif",
+          "height": 8,
           "left": 4,
           "marginTop": 4,
           "muiPrepared": true,
           "position": "absolute",
-          "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+          "transition": "all 400ms cubic-bezier(0.4, 0.0, 0.2, 1)",
           "width": 8,
         }
       }
@@ -393,14 +413,16 @@ exports[`onDotClick handler 1`] = `
           Object {
             "WebkitTapHighlightColor": "rgba(0,0,0,0)",
             "backgroundColor": "#fff",
-            "borderRadius": "50%",
+            "borderRadius": 4,
             "boxShadow": undefined,
             "boxSizing": "border-box",
             "color": "rgba(0, 0, 0, 0.87)",
             "fontFamily": "Roboto, sans-serif",
+            "height": 8,
             "muiPrepared": true,
             "opacity": 0,
-            "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+            "transition": "all 400ms cubic-bezier(0.4, 0.0, 0.2, 1)",
+            "width": 8,
           }
         }
       />
@@ -424,14 +446,16 @@ exports[`onDotClick handler 1`] = `
           Object {
             "WebkitTapHighlightColor": "rgba(0,0,0,0)",
             "backgroundColor": "#fff",
-            "borderRadius": "50%",
+            "borderRadius": 4,
             "boxShadow": undefined,
             "boxSizing": "border-box",
             "color": "rgba(0, 0, 0, 0.87)",
             "fontFamily": "Roboto, sans-serif",
+            "height": 8,
             "muiPrepared": true,
             "opacity": 0.5,
-            "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+            "transition": "all 400ms cubic-bezier(0.4, 0.0, 0.2, 1)",
+            "width": 8,
           }
         }
       />
@@ -455,14 +479,16 @@ exports[`onDotClick handler 1`] = `
           Object {
             "WebkitTapHighlightColor": "rgba(0,0,0,0)",
             "backgroundColor": "#fff",
-            "borderRadius": "50%",
+            "borderRadius": 4,
             "boxShadow": undefined,
             "boxSizing": "border-box",
             "color": "rgba(0, 0, 0, 0.87)",
             "fontFamily": "Roboto, sans-serif",
+            "height": 8,
             "muiPrepared": true,
             "opacity": 0.5,
-            "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+            "transition": "all 400ms cubic-bezier(0.4, 0.0, 0.2, 1)",
+            "width": 8,
           }
         }
       />
@@ -472,16 +498,17 @@ exports[`onDotClick handler 1`] = `
         Object {
           "WebkitTapHighlightColor": "rgba(0,0,0,0)",
           "backgroundColor": "#fff",
-          "borderRadius": 2,
+          "borderRadius": 4,
           "boxShadow": undefined,
           "boxSizing": "border-box",
           "color": "rgba(0, 0, 0, 0.87)",
           "fontFamily": "Roboto, sans-serif",
+          "height": 8,
           "left": 4,
           "marginTop": 4,
           "muiPrepared": true,
           "position": "absolute",
-          "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+          "transition": "all 400ms cubic-bezier(0.4, 0.0, 0.2, 1)",
           "width": 8,
         }
       }
@@ -525,14 +552,16 @@ exports[`three dots, first is selected 1`] = `
           Object {
             "WebkitTapHighlightColor": "rgba(0,0,0,0)",
             "backgroundColor": "#fff",
-            "borderRadius": "50%",
+            "borderRadius": 4,
             "boxShadow": undefined,
             "boxSizing": "border-box",
             "color": "rgba(0, 0, 0, 0.87)",
             "fontFamily": "Roboto, sans-serif",
+            "height": 8,
             "muiPrepared": true,
             "opacity": 0,
-            "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+            "transition": "all 400ms cubic-bezier(0.4, 0.0, 0.2, 1)",
+            "width": 8,
           }
         }
       />
@@ -556,14 +585,16 @@ exports[`three dots, first is selected 1`] = `
           Object {
             "WebkitTapHighlightColor": "rgba(0,0,0,0)",
             "backgroundColor": "#fff",
-            "borderRadius": "50%",
+            "borderRadius": 4,
             "boxShadow": undefined,
             "boxSizing": "border-box",
             "color": "rgba(0, 0, 0, 0.87)",
             "fontFamily": "Roboto, sans-serif",
+            "height": 8,
             "muiPrepared": true,
             "opacity": 0.5,
-            "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+            "transition": "all 400ms cubic-bezier(0.4, 0.0, 0.2, 1)",
+            "width": 8,
           }
         }
       />
@@ -587,14 +618,16 @@ exports[`three dots, first is selected 1`] = `
           Object {
             "WebkitTapHighlightColor": "rgba(0,0,0,0)",
             "backgroundColor": "#fff",
-            "borderRadius": "50%",
+            "borderRadius": 4,
             "boxShadow": undefined,
             "boxSizing": "border-box",
             "color": "rgba(0, 0, 0, 0.87)",
             "fontFamily": "Roboto, sans-serif",
+            "height": 8,
             "muiPrepared": true,
             "opacity": 0.5,
-            "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+            "transition": "all 400ms cubic-bezier(0.4, 0.0, 0.2, 1)",
+            "width": 8,
           }
         }
       />
@@ -604,16 +637,17 @@ exports[`three dots, first is selected 1`] = `
         Object {
           "WebkitTapHighlightColor": "rgba(0,0,0,0)",
           "backgroundColor": "#fff",
-          "borderRadius": 2,
+          "borderRadius": 4,
           "boxShadow": undefined,
           "boxSizing": "border-box",
           "color": "rgba(0, 0, 0, 0.87)",
           "fontFamily": "Roboto, sans-serif",
+          "height": 8,
           "left": 4,
           "marginTop": 4,
           "muiPrepared": true,
           "position": "absolute",
-          "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+          "transition": "all 400ms cubic-bezier(0.4, 0.0, 0.2, 1)",
           "width": 8,
         }
       }

--- a/src/__snapshots__/Dots.spec.js.snap
+++ b/src/__snapshots__/Dots.spec.js.snap
@@ -35,16 +35,14 @@ exports[`custom dot color 1`] = `
           Object {
             "WebkitTapHighlightColor": "rgba(0,0,0,0)",
             "backgroundColor": "red",
-            "borderRadius": 4,
+            "borderRadius": "50%",
             "boxShadow": undefined,
             "boxSizing": "border-box",
             "color": "rgba(0, 0, 0, 0.87)",
             "fontFamily": "Roboto, sans-serif",
-            "height": 8,
             "muiPrepared": true,
             "opacity": 0,
-            "transition": "all 400ms cubic-bezier(0.4, 0.0, 0.2, 1)",
-            "width": 8,
+            "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
           }
         }
       />
@@ -68,16 +66,14 @@ exports[`custom dot color 1`] = `
           Object {
             "WebkitTapHighlightColor": "rgba(0,0,0,0)",
             "backgroundColor": "red",
-            "borderRadius": 4,
+            "borderRadius": "50%",
             "boxShadow": undefined,
             "boxSizing": "border-box",
             "color": "rgba(0, 0, 0, 0.87)",
             "fontFamily": "Roboto, sans-serif",
-            "height": 8,
             "muiPrepared": true,
             "opacity": 0.5,
-            "transition": "all 400ms cubic-bezier(0.4, 0.0, 0.2, 1)",
-            "width": 8,
+            "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
           }
         }
       />
@@ -101,16 +97,14 @@ exports[`custom dot color 1`] = `
           Object {
             "WebkitTapHighlightColor": "rgba(0,0,0,0)",
             "backgroundColor": "red",
-            "borderRadius": 4,
+            "borderRadius": "50%",
             "boxShadow": undefined,
             "boxSizing": "border-box",
             "color": "rgba(0, 0, 0, 0.87)",
             "fontFamily": "Roboto, sans-serif",
-            "height": 8,
             "muiPrepared": true,
             "opacity": 0.5,
-            "transition": "all 400ms cubic-bezier(0.4, 0.0, 0.2, 1)",
-            "width": 8,
+            "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
           }
         }
       />
@@ -134,16 +128,14 @@ exports[`custom dot color 1`] = `
           Object {
             "WebkitTapHighlightColor": "rgba(0,0,0,0)",
             "backgroundColor": "red",
-            "borderRadius": 4,
+            "borderRadius": "50%",
             "boxShadow": undefined,
             "boxSizing": "border-box",
             "color": "rgba(0, 0, 0, 0.87)",
             "fontFamily": "Roboto, sans-serif",
-            "height": 8,
             "muiPrepared": true,
             "opacity": 0.5,
-            "transition": "all 400ms cubic-bezier(0.4, 0.0, 0.2, 1)",
-            "width": 8,
+            "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
           }
         }
       />
@@ -153,17 +145,16 @@ exports[`custom dot color 1`] = `
         Object {
           "WebkitTapHighlightColor": "rgba(0,0,0,0)",
           "backgroundColor": "red",
-          "borderRadius": 4,
+          "borderRadius": 2,
           "boxShadow": undefined,
           "boxSizing": "border-box",
           "color": "rgba(0, 0, 0, 0.87)",
           "fontFamily": "Roboto, sans-serif",
-          "height": 8,
           "left": 4,
           "marginTop": 4,
           "muiPrepared": true,
           "position": "absolute",
-          "transition": "all 400ms cubic-bezier(0.4, 0.0, 0.2, 1)",
+          "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
           "width": 8,
         }
       }
@@ -208,16 +199,14 @@ exports[`custom style 1`] = `
           Object {
             "WebkitTapHighlightColor": "rgba(0,0,0,0)",
             "backgroundColor": "#fff",
-            "borderRadius": 4,
+            "borderRadius": "50%",
             "boxShadow": undefined,
             "boxSizing": "border-box",
             "color": "rgba(0, 0, 0, 0.87)",
             "fontFamily": "Roboto, sans-serif",
-            "height": 8,
             "muiPrepared": true,
             "opacity": 0,
-            "transition": "all 400ms cubic-bezier(0.4, 0.0, 0.2, 1)",
-            "width": 8,
+            "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
           }
         }
       />
@@ -241,16 +230,14 @@ exports[`custom style 1`] = `
           Object {
             "WebkitTapHighlightColor": "rgba(0,0,0,0)",
             "backgroundColor": "#fff",
-            "borderRadius": 4,
+            "borderRadius": "50%",
             "boxShadow": undefined,
             "boxSizing": "border-box",
             "color": "rgba(0, 0, 0, 0.87)",
             "fontFamily": "Roboto, sans-serif",
-            "height": 8,
             "muiPrepared": true,
             "opacity": 0.5,
-            "transition": "all 400ms cubic-bezier(0.4, 0.0, 0.2, 1)",
-            "width": 8,
+            "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
           }
         }
       />
@@ -274,16 +261,14 @@ exports[`custom style 1`] = `
           Object {
             "WebkitTapHighlightColor": "rgba(0,0,0,0)",
             "backgroundColor": "#fff",
-            "borderRadius": 4,
+            "borderRadius": "50%",
             "boxShadow": undefined,
             "boxSizing": "border-box",
             "color": "rgba(0, 0, 0, 0.87)",
             "fontFamily": "Roboto, sans-serif",
-            "height": 8,
             "muiPrepared": true,
             "opacity": 0.5,
-            "transition": "all 400ms cubic-bezier(0.4, 0.0, 0.2, 1)",
-            "width": 8,
+            "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
           }
         }
       />
@@ -307,16 +292,14 @@ exports[`custom style 1`] = `
           Object {
             "WebkitTapHighlightColor": "rgba(0,0,0,0)",
             "backgroundColor": "#fff",
-            "borderRadius": 4,
+            "borderRadius": "50%",
             "boxShadow": undefined,
             "boxSizing": "border-box",
             "color": "rgba(0, 0, 0, 0.87)",
             "fontFamily": "Roboto, sans-serif",
-            "height": 8,
             "muiPrepared": true,
             "opacity": 0.5,
-            "transition": "all 400ms cubic-bezier(0.4, 0.0, 0.2, 1)",
-            "width": 8,
+            "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
           }
         }
       />
@@ -340,16 +323,14 @@ exports[`custom style 1`] = `
           Object {
             "WebkitTapHighlightColor": "rgba(0,0,0,0)",
             "backgroundColor": "#fff",
-            "borderRadius": 4,
+            "borderRadius": "50%",
             "boxShadow": undefined,
             "boxSizing": "border-box",
             "color": "rgba(0, 0, 0, 0.87)",
             "fontFamily": "Roboto, sans-serif",
-            "height": 8,
             "muiPrepared": true,
             "opacity": 0.5,
-            "transition": "all 400ms cubic-bezier(0.4, 0.0, 0.2, 1)",
-            "width": 8,
+            "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
           }
         }
       />
@@ -359,17 +340,16 @@ exports[`custom style 1`] = `
         Object {
           "WebkitTapHighlightColor": "rgba(0,0,0,0)",
           "backgroundColor": "#fff",
-          "borderRadius": 4,
+          "borderRadius": 2,
           "boxShadow": undefined,
           "boxSizing": "border-box",
           "color": "rgba(0, 0, 0, 0.87)",
           "fontFamily": "Roboto, sans-serif",
-          "height": 8,
           "left": 4,
           "marginTop": 4,
           "muiPrepared": true,
           "position": "absolute",
-          "transition": "all 400ms cubic-bezier(0.4, 0.0, 0.2, 1)",
+          "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
           "width": 8,
         }
       }
@@ -413,16 +393,14 @@ exports[`onDotClick handler 1`] = `
           Object {
             "WebkitTapHighlightColor": "rgba(0,0,0,0)",
             "backgroundColor": "#fff",
-            "borderRadius": 4,
+            "borderRadius": "50%",
             "boxShadow": undefined,
             "boxSizing": "border-box",
             "color": "rgba(0, 0, 0, 0.87)",
             "fontFamily": "Roboto, sans-serif",
-            "height": 8,
             "muiPrepared": true,
             "opacity": 0,
-            "transition": "all 400ms cubic-bezier(0.4, 0.0, 0.2, 1)",
-            "width": 8,
+            "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
           }
         }
       />
@@ -446,16 +424,14 @@ exports[`onDotClick handler 1`] = `
           Object {
             "WebkitTapHighlightColor": "rgba(0,0,0,0)",
             "backgroundColor": "#fff",
-            "borderRadius": 4,
+            "borderRadius": "50%",
             "boxShadow": undefined,
             "boxSizing": "border-box",
             "color": "rgba(0, 0, 0, 0.87)",
             "fontFamily": "Roboto, sans-serif",
-            "height": 8,
             "muiPrepared": true,
             "opacity": 0.5,
-            "transition": "all 400ms cubic-bezier(0.4, 0.0, 0.2, 1)",
-            "width": 8,
+            "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
           }
         }
       />
@@ -479,16 +455,14 @@ exports[`onDotClick handler 1`] = `
           Object {
             "WebkitTapHighlightColor": "rgba(0,0,0,0)",
             "backgroundColor": "#fff",
-            "borderRadius": 4,
+            "borderRadius": "50%",
             "boxShadow": undefined,
             "boxSizing": "border-box",
             "color": "rgba(0, 0, 0, 0.87)",
             "fontFamily": "Roboto, sans-serif",
-            "height": 8,
             "muiPrepared": true,
             "opacity": 0.5,
-            "transition": "all 400ms cubic-bezier(0.4, 0.0, 0.2, 1)",
-            "width": 8,
+            "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
           }
         }
       />
@@ -498,17 +472,16 @@ exports[`onDotClick handler 1`] = `
         Object {
           "WebkitTapHighlightColor": "rgba(0,0,0,0)",
           "backgroundColor": "#fff",
-          "borderRadius": 4,
+          "borderRadius": 2,
           "boxShadow": undefined,
           "boxSizing": "border-box",
           "color": "rgba(0, 0, 0, 0.87)",
           "fontFamily": "Roboto, sans-serif",
-          "height": 8,
           "left": 4,
           "marginTop": 4,
           "muiPrepared": true,
           "position": "absolute",
-          "transition": "all 400ms cubic-bezier(0.4, 0.0, 0.2, 1)",
+          "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
           "width": 8,
         }
       }
@@ -552,16 +525,14 @@ exports[`three dots, first is selected 1`] = `
           Object {
             "WebkitTapHighlightColor": "rgba(0,0,0,0)",
             "backgroundColor": "#fff",
-            "borderRadius": 4,
+            "borderRadius": "50%",
             "boxShadow": undefined,
             "boxSizing": "border-box",
             "color": "rgba(0, 0, 0, 0.87)",
             "fontFamily": "Roboto, sans-serif",
-            "height": 8,
             "muiPrepared": true,
             "opacity": 0,
-            "transition": "all 400ms cubic-bezier(0.4, 0.0, 0.2, 1)",
-            "width": 8,
+            "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
           }
         }
       />
@@ -585,16 +556,14 @@ exports[`three dots, first is selected 1`] = `
           Object {
             "WebkitTapHighlightColor": "rgba(0,0,0,0)",
             "backgroundColor": "#fff",
-            "borderRadius": 4,
+            "borderRadius": "50%",
             "boxShadow": undefined,
             "boxSizing": "border-box",
             "color": "rgba(0, 0, 0, 0.87)",
             "fontFamily": "Roboto, sans-serif",
-            "height": 8,
             "muiPrepared": true,
             "opacity": 0.5,
-            "transition": "all 400ms cubic-bezier(0.4, 0.0, 0.2, 1)",
-            "width": 8,
+            "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
           }
         }
       />
@@ -618,16 +587,14 @@ exports[`three dots, first is selected 1`] = `
           Object {
             "WebkitTapHighlightColor": "rgba(0,0,0,0)",
             "backgroundColor": "#fff",
-            "borderRadius": 4,
+            "borderRadius": "50%",
             "boxShadow": undefined,
             "boxSizing": "border-box",
             "color": "rgba(0, 0, 0, 0.87)",
             "fontFamily": "Roboto, sans-serif",
-            "height": 8,
             "muiPrepared": true,
             "opacity": 0.5,
-            "transition": "all 400ms cubic-bezier(0.4, 0.0, 0.2, 1)",
-            "width": 8,
+            "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
           }
         }
       />
@@ -637,17 +604,16 @@ exports[`three dots, first is selected 1`] = `
         Object {
           "WebkitTapHighlightColor": "rgba(0,0,0,0)",
           "backgroundColor": "#fff",
-          "borderRadius": 4,
+          "borderRadius": 2,
           "boxShadow": undefined,
           "boxSizing": "border-box",
           "color": "rgba(0, 0, 0, 0.87)",
           "fontFamily": "Roboto, sans-serif",
-          "height": 8,
           "left": 4,
           "marginTop": 4,
           "muiPrepared": true,
           "position": "absolute",
-          "transition": "all 400ms cubic-bezier(0.4, 0.0, 0.2, 1)",
+          "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
           "width": 8,
         }
       }


### PR DESCRIPTION
Adds a `dotColor` parameter which can be used to restyle the dots in situations where you need a light colour background.

I’ve also made a similar change for material-auto-rotate-carousel to pass down that property, i’ll submit once that PR if/when this one is accepted :)